### PR TITLE
Add Windows build config

### DIFF
--- a/php_extension/README.md
+++ b/php_extension/README.md
@@ -1,0 +1,21 @@
+# litehtmltopng PHP Extension
+
+This extension integrates the litehtmltopng renderer directly into PHP so no
+external binary is required.
+
+## Functions
+
+- `litehtmltopng_version(): string` – returns extension version.
+- `litehtmltopng_render(string $html_file, string $output_png): int` – renders
+  an HTML file to PNG using the bundled litehtml and cairo libraries.
+
+## Building
+
+```sh
+phpize
+./configure --enable-litehtmltopng
+make
+sudo make install
+```
+
+After installation add `extension=litehtmltopng.so` to your `php.ini`.

--- a/php_extension/config.m4
+++ b/php_extension/config.m4
@@ -1,0 +1,12 @@
+PHP_ARG_ENABLE(litehtmltopng, whether to enable litehtmltopng support, [ --enable-litehtmltopng   Enable litehtmltopng support])
+
+if test "$PHP_LITEHTMLTOPNG" != "no"; then
+  PHP_REQUIRE_CXX()
+  PHP_ADD_INCLUDE(../libs/litehtmlcpp98/include)
+  PHP_ADD_INCLUDE(../libs/litehtmlcpp98/src)
+  PHP_ADD_INCLUDE(../libs/litehtmlcpp98/src/litehtml_boost)
+  PHP_ADD_LIBRARY_WITH_PATH(cairo, /usr/lib)
+  PHP_ADD_LIBRARY_WITH_PATH(freetype, /usr/lib)
+  LITEHTML_SRCS="`cd $abs_srcdir/../libs/litehtmlcpp98/src && echo *.cpp`"
+  PHP_NEW_EXTENSION(litehtmltopng, litehtmltopng.cpp render.cpp $LITEHTML_SRCS, $ext_shared,,-std=c++11)
+fi

--- a/php_extension/config.w32
+++ b/php_extension/config.w32
@@ -1,0 +1,18 @@
+// vim:ft=javascript
+ARG_ENABLE('litehtmltopng', 'Enable litehtmltopng support', 'no');
+
+if (PHP_LITEHTMLTOPNG != 'no') {
+    EXTENSION('litehtmltopng', 'litehtmltopng.cpp render.cpp', PHP_LITEHTMLTOPNG_SHARED, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /EHsc');
+    PHP_LITEHTMLTOPNG = 'yes';
+
+    // Add litehtml sources
+    ADD_SOURCES('..\\libs\\litehtmlcpp98\\src', '*.cpp', 'litehtmltopng');
+
+    // Include directories
+    CHECK_HEADER_ADD_INCLUDE('litehtml.h', 'CFLAGS_LITEHTMLTOPNG', '..\\libs\\litehtmlcpp98\\include');
+    CHECK_HEADER_ADD_INCLUDE('cairo.h', 'CFLAGS_LITEHTMLTOPNG', '..\\libs\\cairo\\include');
+    CHECK_HEADER_ADD_INCLUDE('ft2build.h', 'CFLAGS_LITEHTMLTOPNG', '..\\libs\\freetype\\include');
+
+    // Link libraries
+    ADD_FLAG('LIBS_LITEHTMLTOPNG', 'cairo.lib freetype.lib');
+}

--- a/php_extension/litehtmltopng.cpp
+++ b/php_extension/litehtmltopng.cpp
@@ -1,0 +1,61 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include "php.h"
+#include "php_litehtmltopng.h"
+#include <stdlib.h>
+
+int litehtmltopng_render_file(const char* html_file, const char* output_file);
+
+ZEND_BEGIN_ARG_INFO(arginfo_litehtmltopng_version, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_litehtmltopng_render, 0, 0, 2)
+    ZEND_ARG_TYPE_INFO(0, html_file, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, output_file, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+static PHP_FUNCTION(litehtmltopng_version)
+{
+    RETURN_STRING("0.1");
+}
+
+static PHP_FUNCTION(litehtmltopng_render)
+{
+    char *html_file = NULL, *output_file = NULL;
+    size_t html_len = 0, out_len = 0;
+
+    ZEND_PARSE_PARAMETERS_START(2,2)
+        Z_PARAM_STRING(html_file, html_len)
+        Z_PARAM_STRING(output_file, out_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    int ret = litehtmltopng_render_file(html_file, output_file);
+    RETURN_LONG(ret);
+}
+
+static const zend_function_entry litehtmltopng_functions[] = {
+    PHP_FE(litehtmltopng_version, arginfo_litehtmltopng_version)
+    PHP_FE(litehtmltopng_render, arginfo_litehtmltopng_render)
+    PHP_FE_END
+};
+
+zend_module_entry litehtmltopng_module_entry = {
+    STANDARD_MODULE_HEADER,
+    "litehtmltopng",
+    litehtmltopng_functions,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    "0.1",
+    STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_LITEHTMLTOPNG
+# ifdef ZTS
+ZEND_TSRMLS_CACHE_DEFINE()
+# endif
+ZEND_GET_MODULE(litehtmltopng)
+#endif

--- a/php_extension/php_litehtmltopng.h
+++ b/php_extension/php_litehtmltopng.h
@@ -1,0 +1,9 @@
+#ifndef PHP_LITEHTMLTOPNG_H
+#define PHP_LITEHTMLTOPNG_H
+
+extern zend_module_entry litehtmltopng_module_entry;
+#define phpext_litehtmltopng_ptr &litehtmltopng_module_entry
+
+int litehtmltopng_render_file(const char* html_file, const char* output_file);
+
+#endif

--- a/php_extension/render.cpp
+++ b/php_extension/render.cpp
@@ -1,0 +1,101 @@
+#include "php_litehtmltopng.h"
+#include <litehtml.h>
+#include "../libs/litehtmlcpp98/containers/cairo_ft/container_cairo_ft.h"
+#include <cairo.h>
+#include <fstream>
+#include <string>
+
+class php_device_container : public container_cairo_ft
+{
+public:
+    php_device_container(const std::string& root, int width = 384, int dpi = 96)
+        : m_root(root), m_width(width), m_dpi(dpi) {}
+    virtual ~php_device_container() {}
+protected:
+    virtual int device_width_px() const { return m_width; }
+    virtual int device_resolution_dpi() const { return m_dpi; }
+    virtual std::string path_root_resources() const { return m_root; }
+private:
+    std::string m_root;
+    int m_width;
+    int m_dpi;
+    virtual void make_url(const litehtml::tchar_t* url, const litehtml::tchar_t* basepath, litehtml::tstring& out) override
+    {
+        out = m_root + url;
+    }
+    virtual void get_client_rect(litehtml::position& client) const override
+    {
+        client = litehtml::position(0, 0, m_width, 0);
+    }
+    virtual void get_media_features(litehtml::media_features& media) const override
+    {
+        litehtml::position client;
+        get_client_rect(client);
+        media.type = litehtml::media_type_screen;
+        media.width = client.width;
+        media.height = client.height;
+        media.device_width = m_width;
+        media.device_height = client.height;
+        media.color = 8;
+        media.monochrome = 0;
+        media.color_index = 256;
+        media.resolution = m_dpi;
+    }
+    virtual void set_caption(const litehtml::tchar_t* caption) override {}
+    virtual void set_base_url(const litehtml::tchar_t* base_url) override {}
+    virtual void import_css(litehtml::tstring& text, const litehtml::tstring& url, litehtml::tstring& baseurl) override
+    {
+        std::ifstream t(m_root + url);
+        if (t.is_open())
+        {
+            text.assign((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+        }
+    }
+    virtual void on_anchor_click(const litehtml::tchar_t* url, const litehtml::element::ptr& el) override {}
+    virtual void set_cursor(const litehtml::tchar_t* cursor) override {}
+};
+
+int litehtmltopng_render_file(const char* html_file, const char* output_file)
+{
+    std::ifstream html(html_file);
+    if(!html.is_open()) {
+        return -1;
+    }
+    std::string html_text((std::istreambuf_iterator<char>(html)), std::istreambuf_iterator<char>());
+
+    std::string root = "./";
+    std::string path(html_file);
+    auto pos = path.find_last_of('/');
+    if(pos != std::string::npos) {
+        root = path.substr(0, pos + 1);
+    }
+
+    php_device_container container(root);
+    litehtml::context ctx;
+
+    std::ifstream css(root + "master.css");
+    if(css.is_open()) {
+        std::string css_text((std::istreambuf_iterator<char>(css)), std::istreambuf_iterator<char>());
+        ctx.load_master_stylesheet(css_text.c_str());
+    }
+
+    auto doc = litehtml::document::createFromUTF8(html_text.c_str(), &container, &ctx);
+    doc->render(container.device_width_px());
+    int width = doc->width();
+    int height = doc->height();
+
+    cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+    cairo_t* cr = cairo_create(surface);
+    cairo_rectangle(cr, 0, 0, width, height);
+    cairo_clip(cr);
+    cairo_set_source_rgb(cr, 1, 1, 1);
+    cairo_paint(cr);
+    litehtml::position clip(0,0,width,height);
+    doc->draw((litehtml::uint_ptr)cr, 0, 0, &clip);
+
+    cairo_status_t status = cairo_surface_write_to_png(surface, output_file);
+    cairo_destroy(cr);
+    cairo_surface_destroy(surface);
+    return status == CAIRO_STATUS_SUCCESS ? 0 : -1;
+}
+


### PR DESCRIPTION
## Summary
- add `config.w32` for Windows builds

## Testing
- `phpize`
- `./configure --enable-litehtmltopng`
- `make` *(fails: boost/shared_ptr.hpp: No such file or directory)*
- `php -d extension=./modules/litehtmltopng.so -r 'echo litehtmltopng_version();'` *(fails: module not built)*

------
https://chatgpt.com/codex/tasks/task_e_6886a466dbcc8330adfb58b041103496